### PR TITLE
faradayが担っている部分をnet/httpで実装

### DIFF
--- a/lib/slack_notify.rb
+++ b/lib/slack_notify.rb
@@ -1,6 +1,11 @@
 require "slack_notify/version"
+require "slack_notify/error"
+require "slack_notify/connection"
+require "slack_notify/payload"
+require "slack_notify/client"
 
 module SlackNotify
-  class Error < StandardError; end
-  # Your code goes here...
+  def self.new(option = {})
+    SlackNotify::Client.new(option)
+  end
 end

--- a/lib/slack_notify/client.rb
+++ b/lib/slack_notify/client.rb
@@ -3,7 +3,7 @@ require "faraday"
 
 module SlackNotify
   class Client
-    include SlackNotify::Connectionss
+    include SlackNotify::Connection
 
     def initialize(options = {})
       raise ArgumentError, "webhook URL required" unless options[:webhook_url]

--- a/lib/slack_notify/client.rb
+++ b/lib/slack_notify/client.rb
@@ -1,5 +1,7 @@
 require "json"
 require "faraday"
+require "net/http"
+require "uri"
 
 module SlackNotify
   class Client
@@ -32,7 +34,15 @@ module SlackNotify
           link_names: @link_names,
           unfurl_links: @unfurl_links
         )
-        send_payload(payload)
+        uri = URI.parse(@webhook_url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        req = Net::HTTP::Post.new(uri.request_uri)
+        req["Content-Type"] = "application/json"
+        req.body = payload.to_json
+        res = http.request(req)
+        puts "OK"
+        # send_payload(payload)
       end
 
       true

--- a/lib/slack_notify/client.rb
+++ b/lib/slack_notify/client.rb
@@ -25,32 +25,40 @@ module SlackNotify
     end
 
     def notify(text, channel = nil)
-      delivery_channels(channel).each do |chan|
-        payload = {
-          text: text,
-          channel: chan,
-          username: @username,
-          icon_url: @icon_url,
-          icon_emoji: @icon_emoji,
-          link_names: @link_names,
-          unfurl_links: @unfurl_links
-        }
-        uri = URI.parse(@webhook_url)
-        req = Net::HTTP::Post.new(uri.request_uri)
-        req["Content-Type"] = "application/json"
-        req.body = payload.to_json
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.request(req)
-      end
-
-      true
+      chan = delivery_channels(channel)
+      payload = {
+        text: text,
+        channel: chan[0],
+        username: @username,
+        icon_url: @icon_url,
+        icon_emoji: @icon_emoji,
+        link_names: @link_names,
+        unfurl_links: @unfurl_links
+      }
+      uri = URI.parse(@webhook_url)
+      req = Net::HTTP::Post.new(uri.request_uri)
+      req["Content-Type"] = "application/json"
+      req.body = payload.to_json
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      response = http.request(req)
+      handle_response(response)
     end
 
     private
 
       def delivery_channels(channel)
         [channel || @channel || "#general"].flatten.compact.uniq
+      end
+
+      def handle_response(response)
+        unless response.code == "200"
+          if response.body.include?("\n")
+            raise SlackNotify::Error
+          else
+            raise SlackNotify::Error.new(response.body)
+          end
+        end
       end
   end
 end

--- a/lib/slack_notify/client.rb
+++ b/lib/slack_notify/client.rb
@@ -1,0 +1,47 @@
+require "json"
+require "faraday"
+
+module SlackNotify
+  class Client
+    include SlackNotify::Connectionss
+
+    def initialize(options = {})
+      raise ArgumentError, "webhook URL required" unless options[:webhook_url]
+
+      @webhook_url  = options[:webhook_url]
+      @username     = options[:username]
+      @channel      = options[:channel]
+      @icon_url     = options[:icon_url]
+      @icon_emoji   = options[:icon_emoji]
+      @link_names   = options[:link_names]
+      @unfurl_links = options[:unfurl_links] || "1"
+    end
+
+    def test
+      notify("Test Message")
+    end
+
+    def notify(text, channel = nil)
+      delivery_channels(channel).each do |chan|
+        payload = SlackNotify::Payload.new(
+          text: text,
+          channel: chan,
+          username: @username,
+          icon_url: @icon_url,
+          icon_emoji: @icon_emoji,
+          link_names: @link_names,
+          unfurl_links: @unfurl_links
+        )
+        send_payload(payload)
+      end
+
+      true
+    end
+
+    private
+
+      def delivery_channels(channel)
+        [channel || @channel || "#general"].flatten.compact.uniq
+      end
+  end
+end

--- a/lib/slack_notify/client.rb
+++ b/lib/slack_notify/client.rb
@@ -2,6 +2,7 @@ require "json"
 require "faraday"
 require "net/http"
 require "uri"
+require "pry-byebug"
 
 module SlackNotify
   class Client
@@ -25,7 +26,7 @@ module SlackNotify
 
     def notify(text, channel = nil)
       delivery_channels(channel).each do |chan|
-        payload = SlackNotify::Payload.new(
+        payload = {
           text: text,
           channel: chan,
           username: @username,
@@ -33,16 +34,14 @@ module SlackNotify
           icon_emoji: @icon_emoji,
           link_names: @link_names,
           unfurl_links: @unfurl_links
-        )
+        }
         uri = URI.parse(@webhook_url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
         req = Net::HTTP::Post.new(uri.request_uri)
         req["Content-Type"] = "application/json"
         req.body = payload.to_json
-        res = http.request(req)
-        puts "OK"
-        # send_payload(payload)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.request(req)
       end
 
       true

--- a/lib/slack_notify/connection.rb
+++ b/lib/slack_notify/connection.rb
@@ -17,7 +17,11 @@ module SlackNotify
 
     def handle_response(response)
       unless response.success?
-        response.body.include?("\n") ? raise SlackNotify::Error : raise SlackNotify::Error.new(response.body)
+        if response.body.include?("\n")
+          raise SlackNotify::Error
+        else
+          raise SlackNotify::Error.new(response.body)
+        end
       end
     end
   end

--- a/lib/slack_notify/connection.rb
+++ b/lib/slack_notify/connection.rb
@@ -16,7 +16,9 @@ module SlackNotify
     end
 
     def handle_response(response)
-      response.body.include?("\n") ? raise SlackNotify::Error : raise SlackNotify::Error.new(response.body) unless response.success?
+      unless response.success?
+        response.body.include?("\n") ? raise SlackNotify::Error : raise SlackNotify::Error.new(response.body)
+      end
     end
   end
 end

--- a/lib/slack_notify/connection.rb
+++ b/lib/slack_notify/connection.rb
@@ -1,0 +1,22 @@
+module SlackNotify
+  module Connection
+    def send_payload(payload)
+      conn = Faraday.new(@webhook_url) do |c|
+        c.use(Faraday::Request::UrlEncoded)
+        c.adapter(Faraday.default_adapter)
+        c.options.timeout = 5
+        c.options.open_timeout = 5
+      end
+
+      response = conn.post do |req|
+        req.body = JSON.dump(payload.to_hash)
+      end
+
+      handle_response(response)
+    end
+
+    def handle_response(response)
+      response.body.include?("\n") ? raise SlackNotify::Error : raise SlackNotify::Error.new(response.body) unless response.success?
+    end
+  end
+end

--- a/lib/slack_notify/error.rb
+++ b/lib/slack_notify/error.rb
@@ -1,0 +1,3 @@
+module SlackNotify
+  class Error < StandardError ; end
+end

--- a/lib/slack_notify/payload.rb
+++ b/lib/slack_notify/payload.rb
@@ -1,0 +1,37 @@
+module SlackNotify
+  class Payload
+    attr_accessor :username,
+                  :text,
+                  :channel,
+                  :icon_url,
+                  :icon_emoji,
+                  :link_names,
+                  :unfurl_links
+
+    def initialize(options = {})
+      @username     = options[:username] || "webhookbot"
+      @text         = options[:text] || "#general"
+      @channel      = options[:channel]
+      @icon_url     = options[:icon_url]
+      @icon_emoji   = options[:icon_emoji]
+      @link_names   = options[:link_names]
+      @unfurl_links = options[:unfurl_links] || "1"
+
+      @channel = "##{@channel}" unless channel[0] =~ /^(#|@)/
+    end
+
+    def to_hash
+      hash = {
+        text: text,
+        username: username,
+        channel: channel,
+        icon_emoji: icon_emoji,
+        icon_url: icon_url,
+        link_names: link_names,
+        unfurl_links: unfurl_links
+      }
+
+      hash.delete_if { |_,v| v.nil?}
+    end
+  end
+end


### PR DESCRIPTION
gem slack-notifyではfaradayをというgemを使ってHTTP通信を行なっている。
faradayを使わずRubyの組み込みライブラリを使って、HTTP通信を実装してみた。